### PR TITLE
Don't render the Django <1.11 widget on Django >=2

### DIFF
--- a/croppie/widgets/__init__.py
+++ b/croppie/widgets/__init__.py
@@ -1,7 +1,7 @@
 import django
 from django import forms
 
-if django.VERSION[1] < 11:
+if django.VERSION[0] <= 1 and django.VERSION[1] < 11:
     from .widgets_old import CroppieWidget
 else:
     from .widgets import CroppieWidget


### PR DESCRIPTION
Only checking the minor version results in Django 2.0, 2.1, etc. rendering the widget from widgets_old which is incorrect.